### PR TITLE
fix multi-lines css style and exclude 'config' dir in tslint

### DIFF
--- a/web/src/views/pages/HomePage/SidePannel.tsx
+++ b/web/src/views/pages/HomePage/SidePannel.tsx
@@ -14,6 +14,7 @@ const Adress = styled.div`
 	width: 200px;
 	overflow: auto;
 	vertical-align: middle;
+	white-space: nowrap;
 `
 
 const Sider = styled(Layout.Sider)`

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -30,6 +30,7 @@
 	"exclude": [
 		"node_modules",
 		"build",
+		"config",
 		"scripts",
 		"acceptance-tests",
 		"webpack",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3688,13 +3688,9 @@ ignore@^4.0.2:
   version "4.0.3"
   resolved "http://registry.npm.taobao.org/ignore/download/ignore-4.0.3.tgz#e2d58c9654d75b542529fa28d80ac95b29e4f467"
 
-immutable@^3.7.4:
+immutable@^3.7.4, immutable@^3.8.2:
   version "3.8.2"
   resolved "http://registry.npm.taobao.org/immutable/download/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-
-immutable@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
 immutable@~3.7.4:
   version "3.7.6"


### PR DESCRIPTION
fix multi-lines css style and exclude 'config' dir in tslint #71 